### PR TITLE
V2 fix BigDecimalAdapter and those fields as string or array

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.openapi.client.kotlin.openai'
-version '1.1.0'
+version '2.0.0'
 
 buildscript {
     ext.kotlin_version = '1.8.10'
@@ -25,6 +25,16 @@ apply plugin: 'maven-publish'
 repositories {
     mavenLocal()
     mavenCentral()
+}
+
+java.sourceCompatibility = JavaVersion.VERSION_17
+java.targetCompatibility = JavaVersion.VERSION_17
+
+// kotlin target to 17
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 test {

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/apis/OpenAIApi.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/apis/OpenAIApi.kt
@@ -1,41 +1,11 @@
 package org.openapi.client.kotlin.openai.apis
 
-import org.openapi.client.kotlin.openai.infrastructure.CollectionFormats.*
-import retrofit2.http.*
-import retrofit2.Response
-import okhttp3.RequestBody
 import com.squareup.moshi.Json
-
-import org.openapi.client.kotlin.openai.models.CreateAnswerRequest
-import org.openapi.client.kotlin.openai.models.CreateAnswerResponse
-import org.openapi.client.kotlin.openai.models.CreateClassificationRequest
-import org.openapi.client.kotlin.openai.models.CreateClassificationResponse
-import org.openapi.client.kotlin.openai.models.CreateCompletionRequest
-import org.openapi.client.kotlin.openai.models.CreateCompletionResponse
-import org.openapi.client.kotlin.openai.models.CreateEditRequest
-import org.openapi.client.kotlin.openai.models.CreateEditResponse
-import org.openapi.client.kotlin.openai.models.CreateEmbeddingRequest
-import org.openapi.client.kotlin.openai.models.CreateEmbeddingResponse
-import org.openapi.client.kotlin.openai.models.CreateFineTuneRequest
-import org.openapi.client.kotlin.openai.models.CreateImageRequest
-import org.openapi.client.kotlin.openai.models.CreateModerationRequest
-import org.openapi.client.kotlin.openai.models.CreateModerationResponse
-import org.openapi.client.kotlin.openai.models.CreateSearchRequest
-import org.openapi.client.kotlin.openai.models.CreateSearchResponse
-import org.openapi.client.kotlin.openai.models.DeleteFileResponse
-import org.openapi.client.kotlin.openai.models.DeleteModelResponse
-import org.openapi.client.kotlin.openai.models.Engine
-import org.openapi.client.kotlin.openai.models.FineTune
-import org.openapi.client.kotlin.openai.models.ImagesResponse
-import org.openapi.client.kotlin.openai.models.ListEnginesResponse
-import org.openapi.client.kotlin.openai.models.ListFilesResponse
-import org.openapi.client.kotlin.openai.models.ListFineTuneEventsResponse
-import org.openapi.client.kotlin.openai.models.ListFineTunesResponse
-import org.openapi.client.kotlin.openai.models.ListModelsResponse
-import org.openapi.client.kotlin.openai.models.Model
-import org.openapi.client.kotlin.openai.models.OpenAIFile
-
 import okhttp3.MultipartBody
+import org.openapi.client.kotlin.openai.infrastructure.CollectionFormats.*
+import org.openapi.client.kotlin.openai.models.*
+import retrofit2.Response
+import retrofit2.http.*
 
 interface OpenAIApi {
     /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/ApiClient.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/ApiClient.kt
@@ -1,15 +1,15 @@
 package org.openapi.client.kotlin.openai.infrastructure
 
 
+import com.squareup.moshi.Moshi
 import okhttp3.Call
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import retrofit2.Retrofit
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Converter
-import retrofit2.converter.scalars.ScalarsConverterFactory
-import com.squareup.moshi.Moshi
+import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
 
 
 class ApiClient(

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/BigDecimalAdapter.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/BigDecimalAdapter.kt
@@ -1,17 +1,36 @@
 package org.openapi.client.kotlin.openai.infrastructure
 
 import com.squareup.moshi.FromJson
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.ToJson
 import java.math.BigDecimal
 
-class BigDecimalAdapter {
-    @ToJson
-    fun toJson(value: BigDecimal): String {
-        return value.toPlainString()
-    }
+class BigDecimalAdapter : com.squareup.moshi.JsonAdapter<BigDecimal>() {
 
     @FromJson
-    fun fromJson(value: String): BigDecimal {
-        return BigDecimal(value)
+    override fun fromJson(reader: JsonReader): BigDecimal? {
+        return reader.nextString().toBigDecimalOrNull()
+    }
+
+    @ToJson
+    override fun toJson(writer: JsonWriter, value: BigDecimal?) {
+        if (value == null) {
+            writer.nullValue()
+            return
+        }
+        writer.value(value)
     }
 }
+
+//class BigDecimalAdapter {
+//    @ToJson
+//    fun toJson(value: BigDecimal): String {
+//        return value.toFloat().toString()//.toPlainString()
+//    }
+//
+//    @FromJson
+//    fun fromJson(value: String): BigDecimal {
+//        return BigDecimal(value)
+//    }
+//}

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/Serializer.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/Serializer.kt
@@ -4,6 +4,7 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 object Serializer {
+
     @JvmStatic
     val moshiBuilder: Moshi.Builder = Moshi.Builder()
         .add(OffsetDateTimeAdapter())

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/UUIDAdapter.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/UUIDAdapter.kt
@@ -2,7 +2,7 @@ package org.openapi.client.kotlin.openai.infrastructure
 
 import com.squareup.moshi.FromJson
 import com.squareup.moshi.ToJson
-import java.util.UUID
+import java.util.*
 
 class UUIDAdapter {
     @ToJson

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/UnwrapAdapter.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/infrastructure/UnwrapAdapter.kt
@@ -1,0 +1,48 @@
+package org.openapi.client.kotlin.openai.infrastructure
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import okio.Buffer
+
+class UnwrapAdapter<T>(
+    private val delegateAdapter: JsonAdapter<T>,
+    private val key: String
+) : JsonAdapter<T>() {
+
+    override fun fromJson(reader: JsonReader): T? {
+        var result: T? = null
+        when (reader.peek()) {
+            JsonReader.Token.BEGIN_OBJECT -> {
+                reader.beginObject()
+                while (reader.hasNext()) {
+                    if (reader.nextName() == key) {
+                        result = delegateAdapter.fromJson(reader)
+                    } else {
+                        reader.skipValue()
+                    }
+                }
+                reader.endObject()
+            }
+            JsonReader.Token.BEGIN_ARRAY -> {
+                val list = mutableListOf<String>()
+                reader.beginArray()
+                while (reader.hasNext()) {
+                    list.add(reader.nextString())
+                }
+                reader.endArray()
+                val source = Buffer().writeUtf8(list.joinToString(",","[","]"))
+                val arrayReader = JsonReader.of(source)
+                result = delegateAdapter.fromJson(arrayReader)
+            }
+            else -> {
+                result = delegateAdapter.fromJson(reader)
+            }
+        }
+        return result
+    }
+
+    override fun toJson(writer: JsonWriter, value: T?) {
+        delegateAdapter.toJson(writer, value)
+            .takeIf { key.isEmpty() } ?: writer.name(key)    }
+}

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateAnswerRequest.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateAnswerRequest.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateAnswerRequestStop
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateAnswerRequestStop.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateAnswerRequestStop.kt
@@ -16,8 +16,6 @@
 package org.openapi.client.kotlin.openai.models
 
 
-import com.squareup.moshi.Json
-
 /**
  * Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence. 
  *

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateAnswerResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateAnswerResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateAnswerResponseSelectedDocumentsInner
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateClassificationResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateClassificationResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateClassificationResponseSelectedExamplesInner
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequest.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequest.kt
@@ -49,7 +49,7 @@ data class CreateCompletionRequest (
     val model: kotlin.String,
 
     @Json(name = "prompt")
-    val prompt: CreateCompletionRequestPrompt? = null,
+    val prompt: Array<String>? = null,
 
     /* The suffix that comes after a completion of inserted text. */
     @Json(name = "suffix")
@@ -61,7 +61,7 @@ data class CreateCompletionRequest (
 
     /* What [sampling temperature](https://towardsdatascience.com/how-to-sample-from-language-models-682bceb97277) to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.  We generally recommend altering this or `top_p` but not both.  */
     @Json(name = "temperature")
-    val temperature: java.math.BigDecimal? = java.math.BigDecimal("1"),
+    val temperature: java.math.BigDecimal? = java.math.BigDecimal("0"),
 
     /* An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.  We generally recommend altering this or `temperature` but not both.  */
     @Json(name = "top_p")
@@ -84,7 +84,7 @@ data class CreateCompletionRequest (
     val echo: kotlin.Boolean? = false,
 
     @Json(name = "stop")
-    val stop: CreateCompletionRequestStop? = null,
+    val stop: Array<String>? = null,
 
     /* Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics.  [See more information about frequency and presence penalties.](/docs/api-reference/parameter-details)  */
     @Json(name = "presence_penalty")

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequest.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequest.kt
@@ -15,10 +15,8 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateCompletionRequestPrompt
-import org.openapi.client.kotlin.openai.models.CreateCompletionRequestStop
-
 import com.squareup.moshi.Json
+import java.math.BigDecimal
 
 /**
  * 
@@ -61,7 +59,7 @@ data class CreateCompletionRequest (
 
     /* What [sampling temperature](https://towardsdatascience.com/how-to-sample-from-language-models-682bceb97277) to use. Higher values means the model will take more risks. Try 0.9 for more creative applications, and 0 (argmax sampling) for ones with a well-defined answer.  We generally recommend altering this or `top_p` but not both.  */
     @Json(name = "temperature")
-    val temperature: java.math.BigDecimal? = java.math.BigDecimal("0"),
+    val temperature: java.math.BigDecimal? = BigDecimal.ZERO,
 
     /* An alternative to sampling with temperature, called nucleus sampling, where the model considers the results of the tokens with top_p probability mass. So 0.1 means only the tokens comprising the top 10% probability mass are considered.  We generally recommend altering this or `temperature` but not both.  */
     @Json(name = "top_p")

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequestPrompt.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequestPrompt.kt
@@ -16,8 +16,6 @@
 package org.openapi.client.kotlin.openai.models
 
 
-import com.squareup.moshi.Json
-
 /**
  * The prompt(s) to generate completions for, encoded as a string, array of strings, array of tokens, or array of token arrays.  Note that <|endoftext|> is the document separator that the model sees during training, so if a prompt is not specified the model will generate as if from the beginning of a new document. 
  *

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequestPrompt.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequestPrompt.kt
@@ -24,14 +24,14 @@ import com.squareup.moshi.Json
  */
 
 
-data class CreateCompletionRequestPrompt (private val value: Any) {
+data class CreateCompletionRequestPrompt (private val value: Any): ValueOnly {
     init {
         require(value is String || value is Array<*>) {
             "value must be initialized with a String or an Array of Strings"
         }
     }
 
-    fun getValue(): Any {
+    override fun getValue(): Any {
         return value
     }
 }

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequestStop.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionRequestStop.kt
@@ -16,8 +16,6 @@
 package org.openapi.client.kotlin.openai.models
 
 
-import com.squareup.moshi.Json
-
 /**
  * Up to 4 sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence. 
  *

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionResponse.kt
@@ -15,9 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateCompletionResponseChoicesInner
-import org.openapi.client.kotlin.openai.models.CreateCompletionResponseUsage
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionResponseChoicesInner.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateCompletionResponseChoicesInner.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateCompletionResponseChoicesInnerLogprobs
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateEditResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateEditResponse.kt
@@ -15,9 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateCompletionResponseChoicesInner
-import org.openapi.client.kotlin.openai.models.CreateCompletionResponseUsage
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateEmbeddingRequest.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateEmbeddingRequest.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateEmbeddingRequestInput
-
 import com.squareup.moshi.Json
 
 /**
@@ -35,7 +33,7 @@ data class CreateEmbeddingRequest (
     val model: kotlin.String,
 
     @Json(name = "input")
-    val input: CreateEmbeddingRequestInput,
+    val input: Array<String>,
 
     /* A unique identifier representing your end-user, which can help OpenAI to monitor and detect abuse. [Learn more](/docs/guides/safety-best-practices/end-user-ids).  */
     @Json(name = "user")

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateEmbeddingRequestInput.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateEmbeddingRequestInput.kt
@@ -16,8 +16,6 @@
 package org.openapi.client.kotlin.openai.models
 
 
-import com.squareup.moshi.Json
-
 /**
  * Input text to get embeddings for, encoded as a string or array of tokens. To get embeddings for multiple inputs in a single request, pass an array of strings or array of token arrays. Each input must not exceed 8192 tokens in length. 
  *

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateEmbeddingResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateEmbeddingResponse.kt
@@ -15,9 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateEmbeddingResponseDataInner
-import org.openapi.client.kotlin.openai.models.CreateEmbeddingResponseUsage
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateModerationRequest.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateModerationRequest.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateModerationRequestInput
-
 import com.squareup.moshi.Json
 
 /**
@@ -30,7 +28,7 @@ import com.squareup.moshi.Json
 data class CreateModerationRequest (
 
     @Json(name = "input")
-    val input: CreateModerationRequestInput,
+    val input: Array<String>,
 
     /* Two content moderations models are available: `text-moderation-stable` and `text-moderation-latest`.  The default is `text-moderation-latest` which will be automatically upgraded over time. This ensures you are always using our most accurate model. If you use `text-moderation-stable`, we will provide advanced notice before updating the model. Accuracy of `text-moderation-stable` may be slightly lower than for `text-moderation-latest`.  */
     @Json(name = "model")

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateModerationRequestInput.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateModerationRequestInput.kt
@@ -16,8 +16,6 @@
 package org.openapi.client.kotlin.openai.models
 
 
-import com.squareup.moshi.Json
-
 /**
  * The input text to classify
  *

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateModerationResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateModerationResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateModerationResponseResultsInner
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateModerationResponseResultsInner.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateModerationResponseResultsInner.kt
@@ -15,9 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateModerationResponseResultsInnerCategories
-import org.openapi.client.kotlin.openai.models.CreateModerationResponseResultsInnerCategoryScores
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateSearchResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/CreateSearchResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.CreateSearchResponseDataInner
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/FineTune.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/FineTune.kt
@@ -15,9 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.FineTuneEvent
-import org.openapi.client.kotlin.openai.models.OpenAIFile
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/ImagesResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/ImagesResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.ImagesResponseDataInner
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListEnginesResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListEnginesResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.Engine
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListFilesResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListFilesResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.OpenAIFile
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListFineTuneEventsResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListFineTuneEventsResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.FineTuneEvent
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListFineTunesResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListFineTunesResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.FineTune
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListModelsResponse.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/ListModelsResponse.kt
@@ -15,8 +15,6 @@
 
 package org.openapi.client.kotlin.openai.models
 
-import org.openapi.client.kotlin.openai.models.Model
-
 import com.squareup.moshi.Json
 
 /**

--- a/src/main/kotlin/org/openapi/client/kotlin/openai/models/ValueOnly.kt
+++ b/src/main/kotlin/org/openapi/client/kotlin/openai/models/ValueOnly.kt
@@ -1,0 +1,5 @@
+package org.openapi.client.kotlin.openai.models
+
+interface ValueOnly {
+    fun getValue(): Any
+}


### PR DESCRIPTION
- fix `BigDecimalAdapter` by extending to `JsonAdapter` otherwise BigDecimal in json is always surrounded by double quote
- some fields are "string or array" (quote from original openai docs) then let's refactory them to `Array<String>` to be easy and get peace